### PR TITLE
Removing access control from streams.jsp page response.

### DIFF
--- a/src/webapps/live/streams.jsp
+++ b/src/webapps/live/streams.jsp
@@ -18,7 +18,8 @@
   //Live streams list returns a json array [] of stream objects, {name:streamName}{name:thatName}
   //as [{name:streamName}{name:thatName}] 
   
-  response.addHeader("Access-Control-Allow-Origin","*");
+// This is now controlled by the CORS filer in WEB-INF/web.xml
+//  response.addHeader("Access-Control-Allow-Origin","*");
   
   ApplicationContext appCtx = (ApplicationContext) application.getAttribute(WebApplicationContext.ROOT_WEB_APPLICATION_CONTEXT_ATTRIBUTE);
   


### PR DESCRIPTION
this is now handled by the CORS filter in the WEB-INF/web.xml of live webapp.

*Be sure to set host to `localhost` if testing locally*