### PR TITLE
Defaulting to MP4 playback fro MP4 files.

### DIFF
--- a/src/webapps/live/playback.jsp
+++ b/src/webapps/live/playback.jsp
@@ -2,7 +2,7 @@
 <%@ page import="org.springframework.context.ApplicationContext,
           com.red5pro.server.secondscreen.net.NetworkUtil,
           org.springframework.web.context.WebApplicationContext,
-          com.infrared5.red5pro.examples.service.LiveStreamListService,
+          com.infrared5.red5pro.live.LiveStreamListService,
           java.util.Map.Entry,
           java.util.Map,
           java.util.Iterator"%>

--- a/src/webapps/live/script/r5pro-playback-failover.js
+++ b/src/webapps/live/script/r5pro-playback-failover.js
@@ -258,6 +258,18 @@
     var streamName = streamData.name;
     baseConfiguration.streamName = streamName;
     setup(streamName, $videoTemplate, vidTemplateHTML);
+
+    // Unless `view=rtmp` is set in the query params, default to MP4 playback if MP4 file.
+    if (targetViewTech !== 'rtmp') {
+      if (streamData.urls && streamData.urls.rtmp) {
+        if (streamData.urls.rtmp.indexOf('mp4') !== -1) {
+          useMP4Fallback(streamData.urls.rtmp)
+        }
+      }
+      return;
+    }
+
+    // Else, proceed to establish a Subscriber through the SDK.
     determineSubscriber(Object.keys(streamData.urls))
       .then(preview)
       .then(subscribe)

--- a/src/webapps/live/script/r5pro-playback-failover.js
+++ b/src/webapps/live/script/r5pro-playback-failover.js
@@ -263,10 +263,10 @@
     if (targetViewTech !== 'rtmp') {
       if (streamData.urls && streamData.urls.rtmp) {
         if (streamData.urls.rtmp.indexOf('mp4') !== -1) {
-          useMP4Fallback(streamData.urls.rtmp)
+          useMP4Fallback(streamData.urls.rtmp);
+          return;
         }
       }
-      return;
     }
 
     // Else, proceed to establish a Subscriber through the SDK.

--- a/src/webapps/live/script/r5pro-viewer-vod-failover.js
+++ b/src/webapps/live/script/r5pro-viewer-vod-failover.js
@@ -193,6 +193,18 @@
      */
     var streamName = streamData.name;
     baseConfiguration.streamName = streamName;
+
+    // Unless `view=rtmp` is set in the query params, default to MP4 playback if MP4 file.
+    if (targetViewTech !== 'rtmp') {
+      if (streamData.urls && streamData.urls.rtmp) {
+        if (streamData.urls.rtmp.indexOf('mp4') !== -1) {
+          useMP4Fallback(streamData.urls.rtmp)
+        }
+      }
+      return;
+    }
+
+    // Else, proceed to establish a Subscriber through the SDK.
     determineSubscriber(Object.keys(streamData.urls))
       .then(preview)
       .then(subscribe)
@@ -227,6 +239,7 @@
   function determineSubscriber (types) {
     console.log('[playback]:: Available types - ' + types + '.');
     return promisify(function (resolve, reject) {
+
       var subscriber = new red5pro.Red5ProSubscriber();
       subscriber.on('*', onSubscriberEvent);
 

--- a/src/webapps/live/script/r5pro-viewer-vod-failover.js
+++ b/src/webapps/live/script/r5pro-viewer-vod-failover.js
@@ -198,10 +198,10 @@
     if (targetViewTech !== 'rtmp') {
       if (streamData.urls && streamData.urls.rtmp) {
         if (streamData.urls.rtmp.indexOf('mp4') !== -1) {
-          useMP4Fallback(streamData.urls.rtmp)
+          useMP4Fallback(streamData.urls.rtmp);
+          return;
         }
       }
-      return;
     }
 
     // Else, proceed to establish a Subscriber through the SDK.

--- a/src/webapps/live/streams.jsp
+++ b/src/webapps/live/streams.jsp
@@ -3,7 +3,7 @@
 <%@ page import="org.springframework.context.ApplicationContext,
 					com.red5pro.server.secondscreen.net.NetworkUtil,
 					org.springframework.web.context.WebApplicationContext,
-					com.infrared5.red5pro.examples.service.LiveStreamListService,					
+					com.infrared5.red5pro.live.LiveStreamListService,					
 					com.google.gson.*,
 					java.util.Map.Entry,
 					java.util.List,

--- a/src/webapps/live/subscribe.jsp
+++ b/src/webapps/live/subscribe.jsp
@@ -1,7 +1,7 @@
 {{> jsp_header }}
 <%@ page import="org.springframework.context.ApplicationContext,
           org.springframework.web.context.WebApplicationContext,
-          com.infrared5.red5pro.examples.service.LiveStreamListService,
+          com.infrared5.red5pro.live.LiveStreamListService,
           java.util.List"%>
 <%
   //LIVE streams page.


### PR DESCRIPTION
To force playback of MP4 files in the Red5 Pro RTMP Subscriber, defined `view=rtmp` query param.