### PR TITLE
Removing additional hls contrib dependency for VOD + videojs

### DIFF
--- a/src/webapps/live/playback.jsp
+++ b/src/webapps/live/playback.jsp
@@ -35,7 +35,7 @@
     <title>Video On Demand Playback with the Red5 Pro Server!</title>
     <link href="//vjs.zencdn.net/5.19/video-js.min.css" rel="stylesheet">
     <script src="//unpkg.com/video.js/dist/video.js"></script>
-    <script src="//unpkg.com/videojs-contrib-hls/dist/videojs-contrib-hls.js"></script>
+    <!--    <script src="//unpkg.com/videojs-contrib-hls/dist/videojs-contrib-hls.js"></script> -->
     <script src="//unpkg.com/videojs-flash/dist/videojs-flash.js"></script>
     <style>
       object:focus {

--- a/src/webapps/live/viewer-vod.jsp
+++ b/src/webapps/live/viewer-vod.jsp
@@ -46,7 +46,7 @@
         <title>VOD Playback of <%= stream %></title>
     <link href="//vjs.zencdn.net/5.19/video-js.min.css" rel="stylesheet">
     <script src="//unpkg.com/video.js/dist/video.js"></script>
-    <script src="//unpkg.com/videojs-contrib-hls/dist/videojs-contrib-hls.js"></script>
+    <!--    <script src="//unpkg.com/videojs-contrib-hls/dist/videojs-contrib-hls.js"></script> -->
     <script src="//unpkg.com/videojs-flash/dist/videojs-flash.js"></script>
     <script src="//webrtchacks.github.io/adapter/adapter-latest.js"></script>
     <script src="lib/screenfull/screenfull.min.js"></script>


### PR DESCRIPTION
More info: https://github.com/videojs/videojs-contrib-hls/issues/1427

Resolves the following dev console warning:

```
A plugin named "reloadSourceOnError" already exists
```