### PR TITLE
Fixing MP4 location in playback page.

### DIFF
--- a/src/webapps/live/script/r5pro-playback-failover.js
+++ b/src/webapps/live/script/r5pro-playback-failover.js
@@ -183,15 +183,18 @@
   }
 
   function useMP4Fallback (src) {
+    /*
+    // Removing `streams` injection. Path provided in server payloads now.
     var vid = src.split('/');
     var len = vid.length;
     vid.splice(len - 1, 0, 'streams');
     var loc = vid.join('/');
+    */
 
     var element = document.getElementById('red5pro-subscriber');
     var source = document.createElement('source');
     source.type = 'video/mp4;codecs="avc1.42E01E, mp4a.40.2"';
-    source.src = loc;
+    source.src = src;
     element.appendChild(source);
     showSubscriberImplStatus({
       getType: function() {


### PR DESCRIPTION
Was injecting a `streams` directory in the path for MP4 playback. No longer needed, returned in paths from server payload.