### PR TITLE
Buf/safari vod rpro 7065

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,6 @@
     "deploy:qa": "shipit staging buildAndDeploy",
     "deploy:feature": "shipit feature buildAndDeploy",
     "reap": "node red5pro-frontendfile.js",
-    "postdeploy:local": "cp -R /Users/toddanderson/Desktop/red5pro-server-develop.b2375-feature/WEB-INF /Users/toddanderson/Desktop/red5pro-server-develop.b2753-feature/webapps/live && cp -R /Users/toddanderson/Desktop/red5pro-server-develop.b2375-feature/WEB-INF-ROOT /Users/toddanderson/Desktop/red5pro-server-develop.b2753-feature/webapps/root/WEB-INF && cp -R /Users/toddanderson/Desktop/red5pro-server-develop.b2753-feature/streams/** /Users/toddanderson/Desktop/red5pro-server-develop.b2753-feature/webapps/live/streams && cp -R /Users/toddanderson/Desktop/red5pro-server-develop.b2753-feature/apps/** /Users/toddanderson/Desktop/red5pro-server-develop.b2753-feature/webapps/"
+    "postdeploy:local": "cp -R /Users/toddanderson/Desktop/red5pro-server-frontend-files/WEB-INF /Users/toddanderson/Desktop/red5pro-server-frenchie01.b2944-feature/webapps/live && cp -R /Users/toddanderson/Desktop/red5pro-server-frontend-files/WEB-INF-ROOT /Users/toddanderson/Desktop/red5pro-server-frenchie01.b2944-feature/webapps/root/WEB-INF && cp -R /Users/toddanderson/Desktop/red5pro-server-frontend-files/streams/** /Users/toddanderson/Desktop/red5pro-server-frenchie01.b2944-feature/webapps/live/streams && cp -R /Users/toddanderson/Desktop/red5pro-server-frontend-files/apps/** /Users/toddanderson/Desktop/red5pro-server-frenchie01.b2944-feature/webapps/"
   }
 }

--- a/settings.json
+++ b/settings.json
@@ -1,4 +1,4 @@
 {
   "version": "UNKNOWN",
-  "red5pro-server-local": "/Users/toddanderson/Desktop/red5pro-server-develop.b2753-feature"
+  "red5pro-server-local": "/Users/toddanderson/Desktop/red5pro-server-frenchie01.b2944-feature"
 }

--- a/src/template/partial/stream_manager_script.hbs
+++ b/src/template/partial/stream_manager_script.hbs
@@ -3,6 +3,5 @@
     // is_stream_manager is determined in jsp_header.hbs.
     console.log("<%= stream_manager_message %>");
     window.jsp_isStreamManager = <%=is_stream_manager%>;
-    console.log("DEBUGGING: <%= stream_manager_token %>");
   })(window);
 </script>

--- a/src/webapps/live/script/r5pro-playback-failover.js
+++ b/src/webapps/live/script/r5pro-playback-failover.js
@@ -33,8 +33,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
   var targetViewTech = window.r5proViewTech;
   var playbackOrder = targetViewTech ? [targetViewTech] : ['rtmp', 'hls'];
   var protocol = window.location.protocol;
-  var port = window.location.port ? window.location.port : (protocol === 'http' ? 80 : 443);
   protocol = protocol.substring(0, protocol.lastIndexOf(':'));
+  var port = window.location.port ? window.location.port : (protocol === 'http' ? 80 : 443);
 
   var baseConfiguration = {
     host: host,
@@ -113,6 +113,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
   };
 
   var protocol = window.targetProtocol;
+  protocol = protocol.substring(0, protocol.lastIndexOf(':'));
   var doIncludePlaylists = window.requestPlaylists;
   var port = window.location.port ? window.location.port : (protocol === 'https' ? 443 : 80);
 

--- a/src/webapps/live/script/r5pro-playback-failover.js
+++ b/src/webapps/live/script/r5pro-playback-failover.js
@@ -113,7 +113,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
   };
 
   var protocol = window.targetProtocol;
-  protocol = protocol.substring(0, protocol.lastIndexOf(':'));
   var doIncludePlaylists = window.requestPlaylists;
   var port = window.location.port ? window.location.port : (protocol === 'https' ? 443 : 80);
 

--- a/src/webapps/live/script/r5pro-subscriber-failover.js
+++ b/src/webapps/live/script/r5pro-subscriber-failover.js
@@ -35,8 +35,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
   var targetViewTech = window.r5proViewTech;
   var playbackOrder = targetViewTech ? [targetViewTech] : ['rtc', 'rtmp', 'hls'];
   var protocol = window.location.protocol;
-  var port = window.location.port ? window.location.port : (protocol === 'http' ? 80 : 443);
   protocol = protocol.substring(0, protocol.lastIndexOf(':'));
+  var port = window.location.port ? window.location.port : (protocol === 'http' ? 80 : 443);
   function getSocketLocationFromProtocol (protocol) {
     return protocol === 'http' ? {protocol: 'ws', port: 5080} : {protocol: 'wss', port: 443};
   }

--- a/src/webapps/live/script/r5pro-utils.js
+++ b/src/webapps/live/script/r5pro-utils.js
@@ -27,6 +27,19 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 (function (window, Promise, $) {
   'use strict';
 
+  // http://stackoverflow.com/questions/901115/how-can-i-get-query-string-values-in-javascript
+  window.getParameterByName = function (name, url) { // eslint-disable-line no-unused-vars
+    if (!url) {
+      url = window.location.href;
+    }
+    name = name.replace(/[\[\]]/g, "\\$&");
+    var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
+        results = regex.exec(url);
+    if (!results) return null;
+    if (!results[2]) return '';
+    return decodeURIComponent(results[2].replace(/\+/g, " "));
+  }
+
   // If Promise or the Promise polyfill fails (thanks IE!), use jQuery.
   window.promisify = function(fn) {
     if (window.Promise) {

--- a/src/webapps/live/script/r5pro-viewer-failover.js
+++ b/src/webapps/live/script/r5pro-viewer-failover.js
@@ -58,8 +58,8 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
   var iceServers = window.r5proIce;
   var protocol = window.location.protocol;
-  var port = window.location.port ? window.location.port : (protocol === 'http' ? 80 : 443);
   protocol = protocol.substring(0, protocol.lastIndexOf(':'));
+  var port = window.location.port ? window.location.port : (protocol === 'http' ? 80 : 443);
   function getSocketLocationFromProtocol (protocol) {
     return protocol === 'http' ? {protocol: 'ws', port: 5080} : {protocol: 'wss', port: 443};
   }

--- a/src/webapps/live/viewer-vod.jsp
+++ b/src/webapps/live/viewer-vod.jsp
@@ -119,6 +119,7 @@
       </script>
       <script src="lib/red5pro/red5pro-sdk.min.js"></script>
       <script src="script/r5pro-utils.js"></script>
+      <script src="script/r5pro-sm-utils.js"></script>
       <script src="script/r5pro-autoplay-utils.js"></script>
       <script src="script/r5pro-viewer-vod-failover.js"></script>
       {{> footer }}


### PR DESCRIPTION
For the Standalone VOD page (`viewer-vod.jsp`):

* Typically this page is opened from an external link from the VOD listing page
* Upon launch of the external link it assigns the already aggregated data for the specific video to `window.streamData`
* In most browsers, this window data is carried over for external links. **This is not the case for Safari**.

Fix:

Failover for missing `window.streamData` to request and parse the VOD info again.

---

# Steps to reproduce:

1. Launch Safari
2. Navigate to the VOD page
3. In the listing, click on one of the external links to launch the standalone VOD page

# Expected Result:

1. The page (behind the scenes) makes additional XHR requests for VOD to parse the correct stream item and starts playing back.