### PR TITLE
pointing to testbed feature/subscribe_h264_test

### DIFF
--- a/webapps.json
+++ b/webapps.json
@@ -13,6 +13,6 @@
   },
   "r5pro-testbed": {
     "repositoryUrl": "git@github.com:red5pro/streaming-html5.git",
-    "branch": "epic/HIMALAYAN"
+    "branch": "feature/subscribe_h264_test"
   }
 }


### PR DESCRIPTION
* Branched off `epic/HIMALAYAN`
* Adds `Subscriber - H.264` from testbed